### PR TITLE
feat: Bumped typescript-eslint from 8.25.0 to 8.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"svelte-check": "^4.1.4",
 				"tailwindcss": "^4.0.9",
 				"typescript": "^5.7.3",
-				"typescript-eslint": "^8.25.0",
+				"typescript-eslint": "^8.26.0",
 				"vite": "^6.2.0",
 				"vitest": "^3.0.4"
 			}
@@ -2001,17 +2001,17 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
-			"integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.0.tgz",
+			"integrity": "sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.25.0",
-				"@typescript-eslint/type-utils": "8.25.0",
-				"@typescript-eslint/utils": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0",
+				"@typescript-eslint/scope-manager": "8.26.0",
+				"@typescript-eslint/type-utils": "8.26.0",
+				"@typescript-eslint/utils": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -2027,20 +2027,20 @@
 			"peerDependencies": {
 				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
-			"integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.0.tgz",
+			"integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.25.0",
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/typescript-estree": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0",
+				"@typescript-eslint/scope-manager": "8.26.0",
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/typescript-estree": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2052,18 +2052,18 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
-			"integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz",
+			"integrity": "sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0"
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2074,14 +2074,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
-			"integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.0.tgz",
+			"integrity": "sha512-ruk0RNChLKz3zKGn2LwXuVoeBcUMh+jaqzN461uMMdxy5H9epZqIBtYj7UiPXRuOpaALXGbmRuZQhmwHhaS04Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.25.0",
-				"@typescript-eslint/utils": "8.25.0",
+				"@typescript-eslint/typescript-estree": "8.26.0",
+				"@typescript-eslint/utils": "8.26.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.0.1"
 			},
@@ -2094,13 +2094,13 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
-			"integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.0.tgz",
+			"integrity": "sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2112,14 +2112,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
-			"integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz",
+			"integrity": "sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0",
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -2135,7 +2135,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -2165,16 +2165,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
-			"integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.0.tgz",
+			"integrity": "sha512-2L2tU3FVwhvU14LndnQCA2frYC8JnPDVKyQtWFPf8IYFMt/ykEN1bPolNhNbCVgOmdzTlWdusCTKA/9nKrf8Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.25.0",
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/typescript-estree": "8.25.0"
+				"@typescript-eslint/scope-manager": "8.26.0",
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/typescript-estree": "8.26.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2185,17 +2185,17 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
-			"integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz",
+			"integrity": "sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/types": "8.26.0",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
@@ -5114,15 +5114,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.25.0.tgz",
-			"integrity": "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.26.0.tgz",
+			"integrity": "sha512-PtVz9nAnuNJuAVeUFvwztjuUgSnJInODAUx47VDwWPXzd5vismPOtPtt83tzNXyOjVQbPRp786D6WFW/M2koIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.25.0",
-				"@typescript-eslint/parser": "8.25.0",
-				"@typescript-eslint/utils": "8.25.0"
+				"@typescript-eslint/eslint-plugin": "8.26.0",
+				"@typescript-eslint/parser": "8.26.0",
+				"@typescript-eslint/utils": "8.26.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5133,7 +5133,7 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"svelte-check": "^4.1.4",
 		"tailwindcss": "^4.0.9",
 		"typescript": "^5.7.3",
-		"typescript-eslint": "^8.25.0",
+		"typescript-eslint": "^8.26.0",
 		"vite": "^6.2.0",
 		"vitest": "^3.0.4"
 	}


### PR DESCRIPTION
# Work

Bumped `typescript-eslint` from version 8.25.0 to 8.26.0.

## Release notes:

See this [link](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.26.0).

Importantly for this project it seems to support typescript 5.8. This will help solve the problems in #72.

# Tests

# Future work
