### PR TITLE
chore: Test status check behavior

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Update service tag
         run: |
           echo "${{ needs.extract-service-tag.outputs.version }}" > ./build/galactic-sovereign-frontend/version.txt
-      - name: 'Commit changess'
+      - name: 'Commit changes'
         run: |
           git pull
           git config --global user.name 'totocorpbot'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-	plugins: [enhancedImages(), sveltekit(), tailwindcss()],
+	plugins: [sveltekit(), tailwindcss(), enhancedImages()],
 
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],


### PR DESCRIPTION
# Work

In #161 it seems that a PR was merged despite the status checks failing. This seems to be because of [this](https://emmer.dev/blog/skippable-github-status-checks-aren-t-really-required/) fact: when an action has multiple steps, if one step fails, the following ones are marked as skipped. This is considered `passed` from GitHub's perspective.

There are multiple ways to fix this. One recommended in the article is to use the [alls-green](https://github.com/re-actors/alls-green) action which checks that all steps have passed. This might not be what we want as it prevents having steps that are voluntarily skipped (e.g. database verification or update deployment).

Alternatively, we can add the tests step to the required status checks:

![image](https://github.com/user-attachments/assets/a956d834-4bed-4d9b-914b-4d8c1dbd4e6e)

# Tests

When adding `build-and-test` to the list of required status checks, we see that the PR will bypass those checks when it fails. For example, after voluntarily breaking the build in [f3e2cb6](https://github.com/Knoblauchpilze/galactic-sovereign-frontend/pull/172/commits/f3e2cb6c8b11394589c6777f213ff7ab9492f824), we can see the following:

![image](https://github.com/user-attachments/assets/64c9086d-7e08-4563-8650-b1f794da7168)

When the second status check is not there, we can merge without warnings:

![image](https://github.com/user-attachments/assets/305cd472-d3c2-43d3-b7fa-adb669c0d911)

# Future work

Similar changes need to be made in our other repositories as well.
